### PR TITLE
allows for nx=1 or ny=1 if equal covariance matrices

### DIFF
--- a/R/hotelling.test.r
+++ b/R/hotelling.test.r
@@ -134,7 +134,13 @@ hotelling.stat = function(x, y, shrinkage = FALSE, var.equal = TRUE){
   }
   
   if(var.equal){ #for equal covariance matrices
-    sPooled = ((nx - 1) * sx + (ny - 1) * sy) / (nx + ny - 2)
+    df = nx + ny - 2
+    sPooled = 0
+    if (nx > 1)
+      sPooled = sPooled + (nx - 1) * sx
+    if (ny > 1)
+      sPooled = sPooled + (ny - 1) * sy
+    sPooled = sPooled/df
     sPooledInv = solve(sPooled)
     T2 = t(mx - my) %*% sPooledInv %*% (mx - my) * nx * ny/(nx + ny) 
     denomDegF = nx + ny - p - 1


### PR DESCRIPTION
Currently, sPooled will become a matrix of `NA`'s if one of the two samples is only of size one. The new code uses the same method as in `t.test()`.