### PR TITLE
Fixing bug to enable permutation on univariate case

### DIFF
--- a/R/hotelling.test.r
+++ b/R/hotelling.test.r
@@ -295,8 +295,8 @@ hotelling.test.default = function(x, y, shrinkage = FALSE, var.equal = TRUE, per
     
     for(i in 1:B){
       i1 = sample(idx, nx)
-      x1 = X[i1,]
-      x2 = X[-i1,]
+      x1 = X[i1, ,drop=FALSE]
+      x2 = X[-i1, ,drop=FALSE]
       
       res[i] = hotelling.stat(x = x1, y = x2, shrinkage = shrinkage, var.equal = var.equal)$statistic
       j = j + 1


### PR DESCRIPTION
Hello,
    I recently started using the Hotelling R package and have been very impressed. There's a small bug I came across recently however that's messing a little with my workflow and perhaps confusing others as well. It shows up when using `hotelling.test` in a univariate way with `perm = TRUE` (i.e., using it to perform a permutation t-test). 
For example, this performs a normal t-test perfectly:
```
data(container.df)
hotelling.test(Fe~gp, data = container.df)
```
And this performs a permutation Hotelling's T2  perfectly:
```
hotelling.test(Fe+Al~gp, data = container.df, perm=TRUE)
```
But this throws an unexpected error when trying a permutation t-test:
```
hotelling.test(Fe~gp, data = container.df, perm=TRUE)
Error in hotelling.stat(x = x1, y = x2, shrinkage = shrinkage, var.equal = var.equal): x and y must be either both matrices, or both lists
```
This appears to be because the subsetting brackets in the permutation part of `hotelling.stat` are dropping the matrix form because only a single column is being chosen:
```
    for (i in 1:B) {
      i1 = sample(idx, nx)
      x1 = X[i1, ]
      x2 = X[-i1, ]
```
When setting the subset drop option to FALSE, we get the expected behavior:
```
    for (i in 1:B) {
      i1 = sample(idx, nx)
      x1 = X[i1, ,drop=FALSE]
      x2 = X[-i1, ,drop=FALSE]
```
```
hotelling.test(Fe~gp, data = container.df, perm=TRUE)
|===========================================================================| 100%
```